### PR TITLE
Bug fix: Add a space in front of key while un-registring the dll

### DIFF
--- a/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
+++ b/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
@@ -274,8 +274,8 @@ namespace SharpShell.SharpIconOverlayHandler
                         throw new InvalidOperationException("Cannot open the ShellIconOverlayIdentifiers key.");
 
                     //  Delete the overlay key.
-                    if (overlayIdentifiers.GetSubKeyNames().Any(skn => skn == serverType.Name))
-                        overlayIdentifiers.DeleteSubKey(serverType.Name);
+                    if (overlayIdentifiers.GetSubKeyNames().Any(skn => skn == (" " + serverType.Name)))
+                        overlayIdentifiers.DeleteSubKey(" " + serverType.Name);
                 }
             }
         }


### PR DESCRIPTION
The dll was unable to un-register because of the extra space added during registry key creation.
